### PR TITLE
use justfile for scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,73 +3,53 @@ name: CI
 on:
   pull_request:
     branches: ['master', 'main']
-
   push:
     branches: ['master', 'main']
-
   workflow_dispatch:
 
 jobs:
   create-project:
     runs-on: ubuntu-latest
-
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
       - name: Install falco
-        run: |
-          pip install falco-cli --pre
-
+        run: pip install falco-cli --pre
       - name: Checkout Code Repository
         uses: actions/checkout@v4
-
       # - name: Debugging with ssh
       #   uses: lhotari/action-upterm@v1
-
       - name: Generate a project
         run: falco start-project test-project -b . --skip-new-version-check
         working-directory: ./
-
-      - name: Install hatch
-        run: |
-          pip install hatch
-
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Install just
+        uses: extractions/setup-just@v2
       - name: Run django checks
-        run: |
-          cd test_project && hatch run python manage.py check --fail-level WARNING
+        run: test_project && just manage check --fail-level WARNING
 
   build-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
-
       - name: Install falco
-        run: |
-          pip install falco-cli --pre
-
-      - name: Install hatch
-        run: |
-          pip install hatch
-
+        run: pip install falco-cli --pre
       - name: Generate a project
         run: falco start-project test-project -b . --skip-new-version-check
         working-directory: ./
-
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Install just
+        uses: extractions/setup-just@v2
       - name: Generate requirements.txt
-        run: |
-          cd test_project
-          hatch run python --version
-
+        run: cd test_project && just bootstrap
       - name: Build image
-        run: |
-          cd test_project
-          docker build . -f deploy/Dockerfile
+        run: cd test_project && docker build . -f deploy/Dockerfile
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
       - name: Run django checks
-        run: cd test_project && just manage check --fail-level WARNING
+        run: cd test_project && just dj check --fail-level WARNING
 
   build-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
       - name: Run django checks
-        run: test_project && just manage check --fail-level WARNING
+        run: cd test_project && just manage check --fail-level WARNING
 
   build-image:
     runs-on: ubuntu-latest

--- a/{{ cookiecutter.project_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/ci.yml
@@ -18,72 +18,53 @@ concurrency:
 jobs:
   types:
     runs-on: ubuntu-latest
-    env:
-      DEBUG: True
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-      - name: Install hatch
-        run: |
-          pip install hatch
+          python-version: '3.12'
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Install just
+        uses: extractions/setup-just@v2
       - name: Run mypy
-        run: |
-          hatch run mypy .
+        run: just types
 
   checks:
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ""
-      AWS_SECRET_ACCESS_KEY: ""
-      AWS_S3_REGION_NAME: ""
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-      - name: Install hatch
-        run: |
-          pip install hatch
+          python-version: '3.12'
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Install just
+        uses: extractions/setup-just@v2
       - name: Run deployment checks
-        run: |
-          hatch run python manage.py check --deploy
+        run: just deploy-checks
 
-  pytest:
+  test:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:15
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_PASSWORD: postgres
-    env:
-      DATABASE_URL: "postgres://postgres:postgres@localhost:5432/postgres"
-      DEBUG: True
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-      - name: Install hatch
+          python-version: '3.12'
+      - name: Install Hatch
+        uses: pypa/hatch@install
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Build staticfiles
         run: |
-          pip install hatch
+          just manage tailwind --skip-checks build
+          just manage collectstatic --no-input --skip-checks
+          just manage compress
       - name: Test with pytest
-        run: hatch run test:test
+        run: just test

--- a/{{ cookiecutter.project_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: pypa/hatch@install
       - name: Install just
         uses: extractions/setup-just@v2
-      - name: Run mypy
+      - name: Run type checking
         run: just types
 
   checks:

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -7,40 +7,26 @@
 ## Prerequisites
 
 - `Python 3.11+`
-- `hatch 1.9.1+`
+- [hatch 1.9.1+](https://hatch.pypa.io/latest/)
+- [just](https://github.com/casey/just)
 
 ## Development
 
-### Create a new virtual environment
-
-```shell
-hatch shell
-```
-
-### Install pre-commit
-
-```shell
-git init && pre-commit install
-```
+### Setup project
 
 Ensure that the Python version specified in your `.pre-commit-config.yaml` file aligns with the Python version installed on your system.
 
-### Apply migrations
-
 ```shell
-hatch run migrate
+just setup
 ```
-
-### Create a superuser
-
-Follow the tip described [here](https://falco.oluwatobi.dev/guides/tips_and_extra.html#create-superuser-from-environment-variables) and execute the command below to create a superuser.
-
-```shell
-python manage.py createsuperuser --no-input
-```
+Read the content of the justfile to understand what this command does. Essentially, it sets up your virtual environment, 
+installs the dependencies, runs migrations, and creates a superuser with the credentials `admin@localhost` (email) and `admin` (password).
 
 ### Run the django development server
 
 ```shell
-falco work
+just server
 ```
+
+> [!TIP]
+> Run `just` to see all available commands.

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -15,6 +15,7 @@
 ### Setup project
 
 Ensure that the Python version specified in your `.pre-commit-config.yaml` file aligns with the Python version installed on your system.
+If this is a newly created project, run `git init` first.
 
 ```shell
 just setup

--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -17,7 +17,6 @@ _default:
 
 # Setup local environnment (maybe install hatch and setup postgres (create database, etc..))
 @setup:
-    just clean
     just bootstrap
     just cmd pre-commit install --install-hooks
     just migrate

--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -2,7 +2,7 @@
 
 # List all available commands
 _default:
-    @just --list
+    @just --list --unsorted
 
 # ----------------------------------------------------------------------
 # DEPENDENCIES

--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -1,19 +1,150 @@
+{% raw %}
+set dotenv-load := true
 
+# List all available commands
+_default:
+    @just --list
 
-#[tool.hatch.envs.default.scripts]
-#runserver = ["migrate", "python manage.py tailwind runserver {args}"]
-#migrate = "python manage.py migrate {args}"
-#makemigrations = "python manage.py makemigrations {args}"
-#reset-db = "python manage.py reset_db --noinput"
-#shell = "python manage.py shell_plus {args}"
-#upgrade-deps = ["rm requirements.txt", "hatch env run --env default -- python --version"]
+# ----------------------------------------------------------------------
+# DEPENDENCIES
+# ----------------------------------------------------------------------
 
-#[tool.hatch.envs.test.scripts]
-#test = "pytest {args:tests}"
-#test-cov = "coverage run -m pytest {args:tests}"
-#cov-report = ["- coverage combine", "coverage report"]
-#cov = ["test-cov", "cov-report"]
+# Bootstrap local development environment
+@bootstrap:
+    hatch env create
+    hatch env create dev
+    hatch env create docs
+    just install
 
+# Setup local environnment (maybe install hatch and setup postgres (create database, etc..))
+@setup:
+    just clean
+    just bootstrap
+    just cmd pre-commit install --install-hooks
+    just migrate
+    just createsuperuser
+    just lint
 
-#[tool.hatch.envs.docs.scripts]
-#serve = "sphinx-autobuild docs docs/_build/html --port 8001"
+# Install dependencies
+@install *ARGS:
+    just cmd python --version
+
+# Generate and upgrade dependencies
+@upgrade:
+    just cmd hatch-pip-compile --upgrade
+    just cmd hatch-pip-compile dev --upgrade
+
+# Clean up local development environment
+@clean:
+    hatch env prune
+    rm -f .coverage.*
+
+# ----------------------------------------------------------------------
+# TESTING/TYPES
+# ----------------------------------------------------------------------
+
+# Run the test suite, generate code coverage, and export html report
+@coverage-html: test
+    rm -rf htmlcov
+    @just cmd python -m coverage html --skip-covered --skip-empty
+
+# Run the test suite, generate code coverage, and print report to stdout
+coverage-report: test
+    @just cmd python -m coverage report
+
+# Run tests using pytest
+@test *ARGS:
+    just cmd coverage run -m pytest {{ ARGS }}
+
+# Run mypy on project
+@types:
+    just cmd python -m mypy .
+
+# Run the django deployment checks
+@deploy-checks:
+    just manage check --deploy
+
+# ----------------------------------------------------------------------
+# DJANGO
+# ----------------------------------------------------------------------
+
+# Run a falco command
+@falco *COMMAND:
+    just cmd falco {{ COMMAND }}
+
+# Run a django management command
+@manage *COMMAND:
+    just cmd python -m manage {{ COMMAND }}
+
+# Run the django development server
+@server:
+    just falco work
+
+# Open a Django shell using django-extensions shell_plus command
+@shell:
+    just manage shell_plus
+
+alias mm := makemigrations
+
+# Generate Django migrations
+@makemigrations *APPS:
+    just manage makemigrations {{ APPS }}
+
+# Run Django migrations
+@migrate *ARGS:
+    just manage migrate {{ ARGS }}
+
+# Reset the database
+@reset-db:
+    just manage reset_db --noinput
+
+alias su := createsuperuser
+
+# Quickly create a superuser with the provided credentials
+createsuperuser EMAIL="admin@localhost" PASSWORD="admin":
+    @export DJANGO_SUPERUSER_PASSWORD='{{ PASSWORD }}' && just manage createsuperuser --noinput --email "{{ EMAIL }}"
+
+# Generate admin code for a django app
+@admin APP:
+    just manage admin_generator {{ APP }} | tail -n +2 > {% endraw %}{{ cookiecutter.project_name }}{% raw %}/{{ APP }}/admin.py
+
+# ----------------------------------------------------------------------
+# DOCS
+# ----------------------------------------------------------------------
+
+# Build documentation using Sphinx
+@docs-build LOCATION="docs/_build/html":
+    sphinx-build docs {{ LOCATION }}
+
+# Install documentation dependencies
+@docs-install:
+    hatch run docs:python --version
+
+# Serve documentation locally
+@docs-serve:
+    hatch run docs:sphinx-autobuild docs docs/_build/html --port 8001
+
+# Generate and upgrade documentation dependencies
+docs-upgrade:
+    just cmd hatch-pip-compile dev --upgrade
+
+# ----------------------------------------------------------------------
+# UTILS
+# ----------------------------------------------------------------------
+
+# Run a command within the dev environnment
+@cmd *ARGS:
+    hatch --env dev run {{ ARGS }}
+
+# Run all formatters
+@fmt:
+    just --fmt --unstable
+    hatch fmt --formatter
+    just cmd pre-commit run pyproject-fmt -a
+    just cmd pre-commit run reorder-python-imports -a
+    just cmd pre-commit run djlint-reformat-django -a
+
+# Run pre-commit on all files
+@lint:
+    just cmd pre-commit run --all-files
+{% endraw %}

--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -60,7 +60,7 @@ coverage-report: test
 
 # Run the django deployment checks
 @deploy-checks:
-    just manage check --deploy
+    just dj check --deploy
 
 # ----------------------------------------------------------------------
 # DJANGO
@@ -71,7 +71,7 @@ coverage-report: test
     just cmd falco {{ COMMAND }}
 
 # Run a django management command
-@manage *COMMAND:
+@dj *COMMAND:
     just cmd python -m manage {{ COMMAND }}
 
 # Run the django development server
@@ -80,31 +80,31 @@ coverage-report: test
 
 # Open a Django shell using django-extensions shell_plus command
 @shell:
-    just manage shell_plus
+    just dj shell_plus
 
 alias mm := makemigrations
 
 # Generate Django migrations
 @makemigrations *APPS:
-    just manage makemigrations {{ APPS }}
+    just dj makemigrations {{ APPS }}
 
 # Run Django migrations
 @migrate *ARGS:
-    just manage migrate {{ ARGS }}
+    just dj migrate {{ ARGS }}
 
 # Reset the database
 @reset-db:
-    just manage reset_db --noinput
+    just dj reset_db --noinput
 
 alias su := createsuperuser
 
 # Quickly create a superuser with the provided credentials
 createsuperuser EMAIL="admin@localhost" PASSWORD="admin":
-    @export DJANGO_SUPERUSER_PASSWORD='{{ PASSWORD }}' && just manage createsuperuser --noinput --email "{{ EMAIL }}"
+    @export DJANGO_SUPERUSER_PASSWORD='{{ PASSWORD }}' && just dj createsuperuser --noinput --email "{{ EMAIL }}"
 
 # Generate admin code for a django app
 @admin APP:
-    just manage admin_generator {{ APP }} | tail -n +2 > {% endraw %}{{ cookiecutter.project_name }}{% raw %}/{{ APP }}/admin.py
+    just dj admin_generator {{ APP }} | tail -n +2 > {% endraw %}{{ cookiecutter.project_name }}{% raw %}/{{ APP }}/admin.py
 
 # ----------------------------------------------------------------------
 # DOCS

--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -1,0 +1,19 @@
+
+
+#[tool.hatch.envs.default.scripts]
+#runserver = ["migrate", "python manage.py tailwind runserver {args}"]
+#migrate = "python manage.py migrate {args}"
+#makemigrations = "python manage.py makemigrations {args}"
+#reset-db = "python manage.py reset_db --noinput"
+#shell = "python manage.py shell_plus {args}"
+#upgrade-deps = ["rm requirements.txt", "hatch env run --env default -- python --version"]
+
+#[tool.hatch.envs.test.scripts]
+#test = "pytest {args:tests}"
+#test-cov = "coverage run -m pytest {args:tests}"
+#cov-report = ["- coverage combine", "coverage report"]
+#cov = ["test-cov", "cov-report"]
+
+
+#[tool.hatch.envs.docs.scripts]
+#serve = "sphinx-autobuild docs docs/_build/html --port 8001"

--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -1,5 +1,4 @@
-{% raw %}
-set dotenv-load := true
+{% raw %}set dotenv-load := true
 
 # List all available commands
 _default:

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -100,15 +100,24 @@ type = "pip-compile"
 pip-compile-constraint = "default"
 pip-compile-installer = "uv"
 pip-compile-resolver = "uv"
-dependencies = ["dj-notebook>=0.6.1", "Werkzeug[watchdog]>=3.0.1", "pre-commit", "django-stubs[compatible-mypy]", "falco-cli"]
+lock-filename = "requirements.txt"
 
-[tool.hatch.envs.default.scripts]
-runserver = ["migrate", "python manage.py tailwind runserver {args}"]
-migrate = "python manage.py migrate {args}"
-makemigrations = "python manage.py makemigrations {args}"
-reset-db = "python manage.py reset_db --noinput"
-shell = "python manage.py shell_plus {args}"
-upgrade-deps = ["rm requirements.txt", "hatch env run --env default -- python --version"]
+[tool.hatch.envs.dev]
+dependencies = [
+    "django-browser-reload",
+    "django-debug-toolbar",
+    "dj-notebook>=0.6.1",
+    "Werkzeug[watchdog]>=3.0.1",
+    "django-stubs[compatible-mypy]",
+    "coverage[toml]>=6.5",
+    "pre-commit",
+    "pytest",
+    "pytest-django",
+    "pytest-sugar",
+    "pytest-xdist",
+    "falco-cli"
+]
+lock-filename = "requirements-dev.txt"
 
 [tool.hatch.envs.docs]
 dependencies = [
@@ -120,25 +129,6 @@ dependencies = [
   "myst-parser",
 ]
 lock-filename = "docs/requirements.txt"
-
-[tool.hatch.envs.docs.scripts]
-serve = "sphinx-autobuild docs docs/_build/html --port 8001"
-
-[tool.hatch.envs.test]
-dependencies = [
-  "coverage[toml]>=6.5",
-  "pytest",
-  "pytest-django",
-  "pytest-sugar",
-  "pytest-xdist",
-]
-lock-filename = "tests/requirements.txt"
-
-[tool.hatch.envs.test.scripts]
-test = "pytest {args:tests}"
-test-cov = "coverage run -m pytest {args:tests}"
-cov-report = ["- coverage combine", "coverage report"]
-cov = ["test-cov", "cov-report"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
The watchman PR #28 is what triggered me to add this, pywatchman break my current docker setup, the image fails to build.
I don't want to updae my dockerfile to fix something I only use during dev, and I also always wanted to avoid pushing unecessery requirements to prod. The only thing stopping me from having a separate hatch dev environnment is the scripts, I would need to run them with `hatch run dev:<script>`, this could get annoying quicly, so I decide to use a justfile for scripts instead of relying on the hatch script feature