### PR TITLE
format conflict between reorder-python-import and ruff

### DIFF
--- a/{{ cookiecutter.project_name }}/manage.py
+++ b/{{ cookiecutter.project_name }}/manage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-"""Django's command-line utility for administrative tasks."""
 import os
 import sys
 


### PR DESCRIPTION
reorder-python-imports remove the empty line after the comment while ruff for some reason add its, I haven't found the ruff rules doing this yet to disable it, so this is a temporary solution.