### PR TITLE
Update djlint to add support for django-cotton

### DIFF
--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -55,6 +55,7 @@ blank_line_before_tag = "block,partialdef"
 close_void_tags = true
 format_css = true
 format_js = true
+custom_html = "c-\\w+"
 # TODO: remove T002 when fixed https://github.com/Riverside-Healthcare/djLint/issues/687
 ignore = "H006,H030,H031,T002,H021"
 include = "H017,H035"


### PR DESCRIPTION
Added `custom_html = "c-\\w+"` to the `djlint` config, to support the HTML tags produced from our custom [Django Cotton](https://django-cotton.com) components.