### PR TITLE
fix: bumpver logic

### DIFF
--- a/{{ cookiecutter.project_name }}/justfile
+++ b/{{ cookiecutter.project_name }}/justfile
@@ -147,11 +147,13 @@ docs-upgrade:
     -hatch --env dev run pre-commit run --all-files
 
 # Bump project version and update changelog
-@bumpver version:
+bumpver version:
+    #!/usr/bin/env sh
     just cmd bump-my-version bump {{ version }}
     just cmd git-cliff --output CHANGELOG.md
-    git add -A
-    git commit --amend --no-edit
-    git push
-    git push --tags
+    version = "$(hatch version)"
+    git add CHANGELOG.md
+    git commit -m "Generate changelog for version ${version}"
+    git tag -f "v${version}"
+    git push && git push --tags
 {% endraw %}


### PR DESCRIPTION
Previously because of the fact that I was amending the last commit, which is the reference to the last tag, we lost the reference to the last tag, the result was that git cliff take all preivous commit as the changes for latest tag, it desn't stop at the previous tag because it can't see it anymore after I amend the related commit