### PR TITLE
customizable media root

### DIFF
--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -101,6 +101,7 @@ exclude = [
 ]
 artifacts = [
   "staticfiles",
+  "media",
 ]
 
 [tool.hatch.build.targets.binary]

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -101,7 +101,6 @@ exclude = [
 ]
 artifacts = [
   "staticfiles",
-  "media",
 ]
 
 [tool.hatch.build.targets.binary]

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/__main__.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/__main__.py
@@ -1,9 +1,11 @@
 def main() -> None:
-    from pathlib import Path
     import os
     import sys
+    from pathlib import Path
 
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ cookiecutter.project_name }}.settings")
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "{{ cookiecutter.project_name }}.settings"
+    )
     current_path = Path(__file__).parent.parent.resolve()
     sys.path.append(str(current_path))
 
@@ -27,7 +29,9 @@ def run_setup(_):
     execute_from_command_line(["manage", "setup_periodic_tasks"])
 
     with suppress(CommandError):
-        execute_from_command_line(["manage", "createsuperuser", "--noinput", "--traceback"])
+        execute_from_command_line(
+            ["manage", "createsuperuser", "--noinput", "--traceback"]
+        )
 
 
 def run_gunicorn(argv: list) -> None:

--- a/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings.py
+++ b/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/settings.py
@@ -168,7 +168,7 @@ LOGGING = {
     },
 }
 
-MEDIA_ROOT = APPS_DIR / "media"
+MEDIA_ROOT = env.str("MEDIA_ROOT", default=str(APPS_DIR / "media"))
 
 MEDIA_URL = "/media/"
 


### PR DESCRIPTION
This is mostly useful when using the dinary, the user can choose the folder where to put the media files instead of them being located in the pyapp location